### PR TITLE
Configures URL for APIs separately

### DIFF
--- a/lib/smartystreets.rb
+++ b/lib/smartystreets.rb
@@ -66,13 +66,13 @@ module SmartyStreets
     @@auth_token
   end
 
-  # Set the API url.
+  # Set the Street Address API url.
   #
   # This method can only be called once, but is not required.
   #
   # @param [String] api_url the API url
   # @return nil
-  def self.set_api_url(api_url)
+  def self.set_street_address_api_url(api_url)
     @@lock.synchronize do
       @@api_url = check_type(api_url, String)
       check_argument(!@@api_url.empty?)
@@ -83,7 +83,28 @@ module SmartyStreets
     end
   end
 
-  def self.api_url
+  def self.street_address_api_url
     defined?(@@api_url) ? @@api_url : 'https://api.smartystreets.com'
+  end
+
+  # Set the Zipcode API url.
+  #
+  # This method can only be called once, but is not required.
+  #
+  # @param [String] api_url the API url
+  # @return nil
+  def self.set_zipcode_api_url(api_url)
+    @@lock.synchronize do
+      @@api_url = check_type(api_url, String)
+      check_argument(!@@api_url.empty?)
+      class << self
+        remove_method :set_api_url
+      end
+      nil
+    end
+  end
+
+  def self.zipcode_api_url
+    defined?(@@api_url) ? @@api_url : 'https://us-zipcode.api.smartystreets.com'
   end
 end

--- a/lib/smartystreets/street_address_api.rb
+++ b/lib/smartystreets/street_address_api.rb
@@ -1,7 +1,7 @@
 # -*- encoding: utf-8 -*-
 
 module SmartyStreets
-  
+
   # Exposes calls to the SmartyStreets Street Address API.
   #
   # @author Peter Edge (peter.edge@gmail.com)
@@ -29,7 +29,7 @@ module SmartyStreets
 
 
     @@request_url = LazyLoader.create_lazy_loader do
-      SmartyStreets.api_url + '/street-address'
+      SmartyStreets.street_address_api_url + '/street-address'
     end
 
     def self.request_url

--- a/lib/smartystreets/zipcode_api.rb
+++ b/lib/smartystreets/zipcode_api.rb
@@ -1,7 +1,7 @@
 # -*- encoding: utf-8 -*-
 
 module SmartyStreets
-  
+
   # Exposes calls to the SmartyStreets Zipcode API.
   #
   # @author Peter Edge (peter.edge@gmail.com)
@@ -28,7 +28,7 @@ module SmartyStreets
     end
 
     @@request_url = LazyLoader.create_lazy_loader do
-      SmartyStreets.api_url + '/zipcode'
+      SmartyStreets.zipcode_api_url + '/lookup'
     end
 
     def self.request_url


### PR DESCRIPTION
SmartyStreets is sunsetting their legacy Zipcode API URL on June 22nd 2016, as noted [here](http://status.smartystreets.com/incidents/4hjpfqh9q2k7). This addresses the fact that the Street Address API will have a separate host from the Zipcode API.
